### PR TITLE
Fix missing album art error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # Setuptools distribution folder.
 /dist/
 
+# Setuptools build folder.
+/build/
+
 # Python egg metadata, regenerated from source files by setuptools.
 /*.egg-info
 

--- a/sclib/asyncio.py
+++ b/sclib/asyncio.py
@@ -112,11 +112,13 @@ class Track(sync.Track):
             fp.write(track_mp3_bytes)
             fp.seek(0)
 
-            album_artwork = await get_resource(
-                util.get_large_artwork_url(
-                    self.artwork_url
+            album_artwork = None
+            if self.artwork_url:
+                album_artwork = await get_resource(
+                    util.get_large_artwork_url(
+                        self.artwork_url
+                    )
                 )
-            )
 
             self.write_track_id3(fp, album_artwork)
         except (TypeError, ValueError) as e:

--- a/sclib/sync.py
+++ b/sclib/sync.py
@@ -159,11 +159,13 @@ class Track:
             fp.write(urlopen(stream_url).read())
             fp.seek(0)
 
-            album_artwork = urlopen(
-                util.get_large_artwork_url(
-                    self.artwork_url
-                )
-            ).read()
+            album_artwork = None
+            if self.artwork_url:
+                album_artwork = urlopen(
+                    util.get_large_artwork_url(
+                        self.artwork_url
+                    )
+                ).read()
 
             self.write_track_id3(fp, album_artwork)
         except (TypeError, ValueError) as e:
@@ -182,7 +184,7 @@ class Track:
             )
         )['http_mp3_128_url']
 
-    def write_track_id3(self, track_fp, album_artwork:bytes):
+    def write_track_id3(self, track_fp, album_artwork:bytes = None):
         try:
             audio = mutagen.File(track_fp, filename="x.mp3")
             audio.add_tags()
@@ -207,15 +209,16 @@ class Track:
                 frame.append(str(self.track_no))
                 audio.tags.add(frame)
         # SET ARTWORK
-            audio.tags.add(
-                mutagen.id3.APIC(
-                    encoding=3,
-                    mime='image/jpeg',
-                    type=3,
-                    desc=u'Cover',
-                    data=album_artwork
+            if album_artwork:
+                audio.tags.add(
+                    mutagen.id3.APIC(
+                        encoding=3,
+                        mime='image/jpeg',
+                        type=3,
+                        desc=u'Cover',
+                        data=album_artwork
+                    )
                 )
-            )
             audio.save(track_fp, v1=2)
             self.ready = True
             track_fp.seek(0)


### PR DESCRIPTION
Check album art before saving, so that no error occurs. Here is an example JSON, where you can see that no album art is given: https://api-v2.soundcloud.com/resolve?url=https://soundcloud.com/nachtalb88/sets/meep&client_id=nJEgYbVDhjykb4wrNgX7LS7PM82wc0KI


<details><summary>The error I got</summary>
<p>

```
Traceback (most recent call last):
  File "C:/Users/nachtalb/.PyCharm2019.1/config/scratches/scratch.py", line 15, in <module>
    track.write_mp3_to(fp)
  File "C:\Users\nachtalb\src\soundcloud-lib\sclib\sync.py", line 164, in write_mp3_to
    self.artwork_url
  File "C:\Users\nachtalb\scoop\apps\python\current\lib\urllib\request.py", line 222, in urlopen
    return opener.open(url, data, timeout)
  File "C:\Users\nachtalb\scoop\apps\python\current\lib\urllib\request.py", line 516, in open
    req.timeout = timeout
AttributeError: 'NoneType' object has no attribute 'timeout'
```

</p>
</details>

I also added `builds` folder to the gitignore which is created when using `$ python setup.py install`

PS: Thanks for the package you have created 👍 