### PR TITLE
Fix ssl certificate errors by making an optional ssl_verify setting

### DIFF
--- a/sclib/sync.py
+++ b/sclib/sync.py
@@ -5,10 +5,18 @@ import random
 import io
 import mutagen
 from concurrent import futures
+from ssl import SSLContext
 
+ssl_verify=True
+
+def get_ssl_setting():
+    if ssl_verify:
+        return None
+    else:
+        return SSLContext()
 
 def get_url(url):
-    return urlopen(url).read()
+    return urlopen(url,context=get_ssl_setting()).read()
 
 def get_page(url):
     return get_url(url).decode('utf-8')
@@ -185,7 +193,7 @@ class Track:
         try:
             fp.seek(0)
             stream_url = self.get_stream_url()
-            fp.write(urlopen(stream_url).read())
+            fp.write(urlopen(stream_url,context=get_ssl_setting()).read())
             fp.seek(0)
 
             album_artwork = None
@@ -193,7 +201,7 @@ class Track:
                 album_artwork = urlopen(
                     util.get_large_artwork_url(
                         self.artwork_url
-                    )
+                    ),context=get_ssl_setting()
                 ).read()
 
             self.write_track_id3(fp, album_artwork)


### PR DESCRIPTION
on some py environments you may get ssl verification errors like i did:
```urllib.error.URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1123)>```
to fix this I made ssl verification optional by making an "ssl_verify" option, which is enabled by default like what it was before. If an user wants to disable ssl verification they can simply set sclib.sync.verify_ssl to False and it works again.
```
sclib.sync.verify_ssl=False
track = api.resolve('https://soundcloud.com/itsmeneedle/sunday-morning')
```

