### PR TITLE
Update async clean_attributes

### DIFF
--- a/sclib/asyncio.py
+++ b/sclib/asyncio.py
@@ -89,7 +89,7 @@ class SoundcloudAPI(sync.SoundcloudAPI):
 
         if obj['kind'] == 'playlist':
             playlist = Playlist(obj=obj, client=self)
-            await playlist.clean_attributes()
+            await playlist.async_clean_attributes()
             return playlist
 
     async def get_tracks(self, *track_ids):  # pylint: disable=invalid-overridden-method
@@ -158,11 +158,12 @@ class Track(sync.Track):
 
 
 class Playlist(sync.Playlist):
-    """ Playlist """
+    """ Asynchronous playlist object """
 
     RESOLVE_THRESHOLD = 100
 
-    async def clean_attributes(self): # pylint: disable=invalid-overridden-method
+    async def async_clean_attributes(self): # pylint: disable=invalid-overridden-method
+        """ Async clean_attributes """
         if self.ready:
             return
         self.ready = True
@@ -189,7 +190,7 @@ class Playlist(sync.Playlist):
         return int(self.track_count)
 
     async def __aiter__(self):
-        await self.clean_attributes()
+        await self.async_clean_attributes()
         for track in self.tracks:
             yield track
 


### PR DESCRIPTION
Currently clean_attributes produces a runtime error when it's referenced as self.clean_attributes() as it's trying to call clean_attributes from sync.py

Having a unique name for it means it'll only ever call the function from within the async class.