### PR TITLE
Add support for system-playlist kind so that "discover" playlists are loaded

### DIFF
--- a/sclib/asyncio.py
+++ b/sclib/asyncio.py
@@ -87,7 +87,7 @@ class SoundcloudAPI(sync.SoundcloudAPI):
         if obj['kind'] == 'track':
             return Track(obj=obj, client=self)
 
-        if obj['kind'] == 'playlist':
+        if obj['kind'] in ('playlist', 'system-playlist'):
             playlist = Playlist(obj=obj, client=self)
             await playlist.clean_attributes()
             return playlist

--- a/sclib/asyncio.py
+++ b/sclib/asyncio.py
@@ -184,10 +184,6 @@ class Playlist(sync.Playlist):
             if track not in self.tracks:
                 self.tracks.append(track)
 
-
-    def __len__(self):
-        return int(self.track_count)
-
     async def __aiter__(self):
         await self.clean_attributes()
         for track in self.tracks:

--- a/sclib/sync.py
+++ b/sclib/sync.py
@@ -356,7 +356,7 @@ class Playlist:
         self.tracks = track_objects
 
     def __len__(self):
-        return int(self.track_count)
+        return len(self.tracks)
 
     def __iter__(self):
         self.clean_attributes()

--- a/sclib/sync.py
+++ b/sclib/sync.py
@@ -83,7 +83,7 @@ class SoundcloudAPI:
         obj = get_obj_from(url)
         if obj['kind'] == 'track':
             return Track(obj=obj, client=self)
-        if obj['kind'] == 'playlist':
+        if obj['kind'] in ('playlist', 'system-playlist'):
             playlist = Playlist(obj=obj, client=self)
             playlist.clean_attributes()
             return playlist

--- a/tests/async/test_playlist.py
+++ b/tests/async/test_playlist.py
@@ -25,17 +25,6 @@ async def test_playlist_is_resolved(sclib: SoundcloudAPI, playlist_url: str):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("playlist_url", [
-    "https://soundcloud.com/soundcloud-circuits/sets/web-tempo-future-dance-and-electronic",
-    "https://soundcloud.com/discover/sets/artist-stations:127466931",
-])
-async def test_playlist_size(sclib: SoundcloudAPI, playlist_url: str):
-    """ Test async playlist size """
-    test_playlist = await sclib.resolve(playlist_url)
-    assert len(test_playlist) == len(test_playlist.tracks)
-
-
-@pytest.mark.asyncio
 @pytest.mark.parametrize("playlist_url,expected_playlist_kind", [
     ("https://soundcloud.com/soundcloud-circuits/sets/web-tempo-future-dance-and-electronic", "playlist"),
     ("https://soundcloud.com/discover/sets/artist-stations:127466931", "system-playlist"),

--- a/tests/async/test_playlist.py
+++ b/tests/async/test_playlist.py
@@ -1,23 +1,46 @@
 """
-Test async playlist
+Test async playlists
 """
-import pytest_asyncio
+import pytest
 
-from sclib.asyncio import SoundcloudAPI, Playlist
+from sclib.asyncio import SoundcloudAPI
 
-PLAYLIST_URL = 'https://soundcloud.com/soundcloud-circuits/sets/web-tempo-future-dance-and-electronic'
-TEST_PLAYLIST = None
+pytest_plugins = ('pytest_asyncio',)
 
 
-@pytest_asyncio.fixture(name='test_playlist')
-async def playlist_fixture():
+@pytest.fixture(name='sclib')
+def sclib_fixture():
     """ Ex playlist """
-    return await SoundcloudAPI().resolve(PLAYLIST_URL)
+    return SoundcloudAPI()
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("playlist_url", [
+    "https://soundcloud.com/soundcloud-circuits/sets/web-tempo-future-dance-and-electronic",
+    "https://soundcloud.com/discover/sets/artist-stations:127466931",
+])
+async def test_playlist_is_resolved(sclib: SoundcloudAPI, playlist_url: str):
+    """ Test async playlist is resolved """
+    await sclib.resolve(playlist_url)
 
-def test_playlist_size(test_playlist: Playlist):
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("playlist_url", [
+    "https://soundcloud.com/soundcloud-circuits/sets/web-tempo-future-dance-and-electronic",
+    "https://soundcloud.com/discover/sets/artist-stations:127466931",
+])
+async def test_playlist_size(sclib: SoundcloudAPI, playlist_url: str):
     """ Test async playlist size """
-    assert len(test_playlist) > 0
-    test_playlist.clean_attributes()
+    test_playlist = await sclib.resolve(playlist_url)
     assert len(test_playlist) == len(test_playlist.tracks)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("playlist_url,expected_playlist_kind", [
+    ("https://soundcloud.com/soundcloud-circuits/sets/web-tempo-future-dance-and-electronic", "playlist"),
+    ("https://soundcloud.com/discover/sets/artist-stations:127466931", "system-playlist"),
+])
+async def test_playlist_type(sclib: SoundcloudAPI, playlist_url: str, expected_playlist_kind: str):
+    """ Test async playlist type """
+    test_playlist = await sclib.resolve(playlist_url)
+    assert test_playlist.kind == expected_playlist_kind

--- a/tests/sync/test_playlist.py
+++ b/tests/sync/test_playlist.py
@@ -1,26 +1,41 @@
-""" Test sync playlists """
-
+"""
+Test async playlists
+"""
 import pytest
 
-from sclib import SoundcloudAPI, Playlist
-
-PLAYLIST_URL = 'https://soundcloud.com/soundcloud-circuits/sets/web-tempo-future-dance-and-electronic'
-TEST_PLAYLIST = None
+from sclib.sync import SoundcloudAPI
 
 
-@pytest.fixture(name="playlist")
-def test_playlist():
-    """ Example playlist fixture """
-
-    return SoundcloudAPI().resolve(PLAYLIST_URL)
-
+@pytest.fixture(name='sclib')
+def sclib_fixture():
+    """ Ex playlist """
+    return SoundcloudAPI()
 
 
-def test_playlist_size(playlist: Playlist):
-    """ Test that playlist size is correct """
-    assert len(playlist) > 0 and type(len(playlist)) is int
+@pytest.mark.parametrize("playlist_url", [
+    "https://soundcloud.com/soundcloud-circuits/sets/web-tempo-future-dance-and-electronic",
+    "https://soundcloud.com/discover/sets/artist-stations:127466931",
+])
+def test_playlist_is_resolved(sclib: SoundcloudAPI, playlist_url: str):
+    """ Test async playlist is resolved """
+    sclib.resolve(playlist_url)
 
 
-def test_playlist_fetch_tracks(playlist: Playlist):
-    """ Test that number of tracks matches size of playlist """
-    assert len(playlist.tracks) is len(playlist)
+@pytest.mark.parametrize("playlist_url", [
+    "https://soundcloud.com/soundcloud-circuits/sets/web-tempo-future-dance-and-electronic",
+    "https://soundcloud.com/discover/sets/artist-stations:127466931",
+])
+def test_playlist_size(sclib: SoundcloudAPI, playlist_url: str):
+    """ Test async playlist size """
+    test_playlist = sclib.resolve(playlist_url)
+    assert len(test_playlist) == len(test_playlist.tracks)
+
+
+@pytest.mark.parametrize("playlist_url,expected_playlist_kind", [
+    ("https://soundcloud.com/soundcloud-circuits/sets/web-tempo-future-dance-and-electronic", "playlist"),
+    ("https://soundcloud.com/discover/sets/artist-stations:127466931", "system-playlist"),
+])
+def test_playlist_type(sclib: SoundcloudAPI, playlist_url: str, expected_playlist_kind: str):
+    """ Test async playlist type """
+    test_playlist = sclib.resolve(playlist_url)
+    assert test_playlist.kind == expected_playlist_kind

--- a/tests/sync/test_playlist.py
+++ b/tests/sync/test_playlist.py
@@ -21,16 +21,6 @@ def test_playlist_is_resolved(sclib: SoundcloudAPI, playlist_url: str):
     sclib.resolve(playlist_url)
 
 
-@pytest.mark.parametrize("playlist_url", [
-    "https://soundcloud.com/soundcloud-circuits/sets/web-tempo-future-dance-and-electronic",
-    "https://soundcloud.com/discover/sets/artist-stations:127466931",
-])
-def test_playlist_size(sclib: SoundcloudAPI, playlist_url: str):
-    """ Test async playlist size """
-    test_playlist = sclib.resolve(playlist_url)
-    assert len(test_playlist) == len(test_playlist.tracks)
-
-
 @pytest.mark.parametrize("playlist_url,expected_playlist_kind", [
     ("https://soundcloud.com/soundcloud-circuits/sets/web-tempo-future-dance-and-electronic", "playlist"),
     ("https://soundcloud.com/discover/sets/artist-stations:127466931", "system-playlist"),


### PR DESCRIPTION
Some playlists aren't resolved as their kind is "system-playlist" rather than the expected value of "playlist", but both seem to behave the same for my use-case (fetching track stream urls).

A system-playlist to test and reproduce with:
https://soundcloud.com/discover/sets/your-playback::alexabx:2022

Here's a quick fix, let me know if and how you would like tests implemented.

